### PR TITLE
ICARUS Simple RBF

### DIFF
--- a/rp235xx/icarus/src/startup.rs
+++ b/rp235xx/icarus/src/startup.rs
@@ -265,6 +265,12 @@ pub fn startup(mut ctx: init::Context) -> (Shared, Local) {
     let ina_data = INAData::default();
 
     let mut rbf = pins.gpio4.into_pull_down_input();
+    
+    // Wait for the "Remove Before Flight" (RBF) pin to go low.
+    // The RBF pin is a safety mechanism that ensures certain tasks
+    // do not start until the pin is removed. This loop continuously
+    // checks the state of the pin and delays task initialization
+    // until the pin is confirmed to be low.
     let mut rbf_high = true;
     while(rbf_high) {
         if rbf.is_low().unwrap() {

--- a/rp235xx/icarus/src/startup.rs
+++ b/rp235xx/icarus/src/startup.rs
@@ -1,6 +1,6 @@
 use bin_packets::phases::IcarusPhase;
 use defmt::{info, warn};
-use embedded_hal::{delay::DelayNs, digital::OutputPin};
+use embedded_hal::{delay::DelayNs, digital::{InputPin, OutputPin}};
 use fugit::RateExtU32;
 use hc12_rs::IntoFU3Mode;
 use rp235x_hal::{
@@ -263,6 +263,18 @@ pub fn startup(mut ctx: init::Context) -> (Shared, Local) {
     let ina260_3 = AsyncINA260::new(ArbiterDevice::new(motor_i2c_arbiter), 0x42, Mono);
 
     let ina_data = INAData::default();
+
+    let mut rbf = pins.gpio4.into_pull_down_input();
+    let mut rbf_high = true;
+    while(rbf_high) {
+        if rbf.is_low().unwrap() {
+            rbf_high = false;
+            info!("RBF is low.");
+        } else {
+            rbf_high = true;
+            info!("RBF is high.");
+        }
+    }
 
     info!("Peripherals initialized, spawning tasks...");
     heartbeat::spawn().ok();

--- a/rp235xx/icarus/src/tasks.rs
+++ b/rp235xx/icarus/src/tasks.rs
@@ -129,27 +129,27 @@ pub async fn motor_drivers(
 
         let vs1 = ApplicationPacket::VoltageData {
             time_stamp: ts,
-            power: voltage_1,
+            voltage: voltage_1,
         };
         let vs2 = ApplicationPacket::VoltageData {
             time_stamp: ts,
-            power: voltage_2,
+            voltage: voltage_2,
         };
         let vs3 = ApplicationPacket::VoltageData {
             time_stamp: ts,
-            power: voltage_3,
+            voltage: voltage_3,
         };
         let cur1 = ApplicationPacket::CurrentData {
             time_stamp: ts,
-            power: current_1,
+            current: current_1,
         };
         let cur2 = ApplicationPacket::CurrentData {
             time_stamp: ts,
-            power: current_2,
+            current: current_2,
         };
         let cur3 = ApplicationPacket::CurrentData {
             time_stamp: ts,
-            power: current_3,
+            current: current_3,
         };
         let pow1 = ApplicationPacket::PowerData {
             time_stamp: ts,


### PR DESCRIPTION
This is a simple RBF that allows sensor setup but does not allow task initiation. This should prevent power to servos, as long as they stay commanded in task only.